### PR TITLE
feat(auth): allow the auth token to be set

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-root = true
-
 [*]
 end_of_line = lf
 insert_final_newline = true

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -113,6 +113,13 @@ func (c *Client) IDToken() string {
 	return c.idToken
 }
 
+// SetToken sets the ID Token to use for the Oauth flow.
+func (c *Client) SetToken(t string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.idToken = t
+}
+
 // RefreshToken returns the refresh token obtained from the Oauth flow.
 func (c *Client) refreshToken() string {
 	c.mutex.RLock()

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	a := assert.New(t)
 
 	email := os.Getenv("LR_EMAIL")
@@ -29,4 +33,12 @@ func TestAuth(t *testing.T) {
 		a.NoError(c.Login(ctx))
 		a.NoError(c.DoRefreshToken(ctx))
 	})
+}
+
+func TestSetToken(t *testing.T) {
+	c := New("", "")
+	assert.Empty(t, c.IDToken())
+
+	c.SetToken("notreal")
+	assert.Equal(t, "notreal", c.IDToken())
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,6 +55,10 @@ func (c *Client) Token() string {
 	return c.auth.IDToken()
 }
 
+func (c *Client) SetToken(token string) {
+	c.auth.SetToken(token)
+}
+
 // FetchRobots fetches the robots from the LitterRobot API.
 // The robots are cached on the client and can be fetched without additional network calls using Robots() or Robot(id)
 func (c *Client) FetchRobots(ctx context.Context) error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	a := assert.New(t)
 	email := os.Getenv("LR_EMAIL")
 	password := os.Getenv("LR_PASSWORD")
@@ -31,4 +35,10 @@ func TestClient(t *testing.T) {
 	a.Greater(len(in.CycleHistory), 0)
 
 	a.NoError(c.Cycle(ctx, id))
+}
+
+func TestSetToken(t *testing.T) {
+	c := New("", "")
+	c.SetToken("testing")
+	assert.Equal(t, "testing", c.Token())
 }


### PR DESCRIPTION
Allows the auth token to be set on the client, allowing a token obtained during a prior oauth call to be used to authenticate the client.